### PR TITLE
criação do arquivo do teclado comentada

### DIFF
--- a/pacotes/layout-teclado/scriptUsuarioLocalETeclado.sh
+++ b/pacotes/layout-teclado/scriptUsuarioLocalETeclado.sh
@@ -8,7 +8,6 @@ userdel -r prodap
 echo -e "Criando arquivos de configuração do teclado.\n"
 # cp environment /etc
 echo -e "LANG=pt_BR.utf8\n" > /etc/environment
-# cp 20-keyboard.conf /etc/X11/xorg.conf.d/
-echo -e "Section \"InputClass\" \n        Identifier \"keyboard\"\n        MatchIsKeyboard \"yes\"\n        Option \"XkbLayout\" \"br\"\n        Option \"XkbVariant\" \"abnt2\"
-\nEndSection" > /etc/X11/xorg.conf.d/20-keyboard.conf
+cp 20-keyboard.conf /etc/X11/xorg.conf.d/
+#echo -e "Section \"InputClass\" \n        Identifier \"keyboard\"\n        MatchIsKeyboard \"yes\"\n        Option \"XkbLayout\" \"br\"\n        Option \"XkbVariant\" \"abnt2\"\nEndSection" > /etc/X11/xorg.conf.d/20-keyboard.conf
 echo -e "Pronto.\n"


### PR DESCRIPTION
Em vez de criar o arquivo configurador do teclado, um arquivo já pronto é copiado.